### PR TITLE
fixed navv bar index

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -20,4 +20,5 @@
   position: fixed;
   top: 0;
   background-color: $almost-white;
+  z-index: 9999999;
 }


### PR DESCRIPTION
<img width="1161" alt="Screenshot 2024-11-29 at 4 38 30 PM" src="https://github.com/user-attachments/assets/a7896995-b091-4555-a016-38d5ba95bc90">
now when you scroll down the nav bar always stays on top