### PR TITLE
fixed the new service modal to stay on top

### DIFF
--- a/app/assets/stylesheets/services/_show.scss
+++ b/app/assets/stylesheets/services/_show.scss
@@ -45,3 +45,7 @@
 .custom-textaera::placeholder{
     color: rgba($almost-black, 0.3);
 }
+
+#newServiceModal{
+  z-index: 999999999;
+}


### PR DESCRIPTION
<img width="1240" alt="Screenshot 2024-11-29 at 5 01 52 PM" src="https://github.com/user-attachments/assets/c2429c53-382b-4b60-ad0a-7585dce8d2ee">

now the new service modal will stay on top of everything when you try to add a new service